### PR TITLE
fix module name

### DIFF
--- a/lib/phoenix_html_helpers.ex
+++ b/lib/phoenix_html_helpers.ex
@@ -1,4 +1,4 @@
-defmodule PhoenixHtmlHelpers do
+defmodule PhoenixHTMLHelpers do
   @moduledoc """
   Collection of helpers to generate and manipulate HTML contents.
 


### PR DESCRIPTION
The casing in the main module didn't match the documentation everywhere. Also causes hex docs to link to an invalid URL.