### PR TITLE
Remove a form_for clause that would crash in runtime

### DIFF
--- a/lib/phoenix_html_helpers/form.ex
+++ b/lib/phoenix_html_helpers/form.ex
@@ -32,11 +32,6 @@ defmodule PhoenixHTMLHelpers.Form do
     bin |> String.replace("_", " ") |> :string.titlecase()
   end
 
-  @doc false
-  def form_for(form_data, action) do
-    form_for(form_data, action, [])
-  end
-
   @doc """
   Generates a form tag with a form builder and an anonymous function.
 


### PR DESCRIPTION
Discovered by 1.19 typesystem

```
    warning: incompatible types given to form_for/3:

        form_for(form_data, action, [])

    given types:

        dynamic(), dynamic(), empty_list()

    but expected one of:

        dynamic(), dynamic(), fun()

    where "action" was given the type:

        # type: dynamic()
        # from: lib/phoenix_html_helpers/form.ex:36:27
        action

    where "form_data" was given the type:

        # type: dynamic()
        # from: lib/phoenix_html_helpers/form.ex:36:16
        form_data

    typing violation found at:
    │
 37 │     form_for(form_data, action, [])
    │     ~
    │
    └─ (phoenix_html_helpers 1.0.1) lib/phoenix_html_helpers/form.ex:37:5: PhoenixHTMLHelpers.Form.form_for/2
```

It seems the clause used to work on `phoenix_html` v3.x because there were this https://github.com/phoenixframework/phoenix_html/blob/9a449b7570d027248b5a3157c0a26a4ec6288f6e/lib/phoenix_html/form.ex#L366
Without that it's failing in runtime
```
PhoenixHTMLHelpers.Form.form_for(%{}, :insert)
** (FunctionClauseError) no function clause matching in PhoenixHTMLHelpers.Form.form_for/4    
    
    The following arguments were given to PhoenixHTMLHelpers.Form.form_for/4:
    
        # 1
        %{}
    
        # 2
        :insert
    
        # 3
        []
    
        # 4
        []
    
    Attempted function clauses (showing 1 out of 1):
    
        def form_for(form_data, action, options, fun) when is_function(fun, 1)
    
    (phoenix_html_helpers 1.0.0) lib/phoenix_html_helpers/form.ex:261: PhoenixHTMLHelpers.Form.form_for/4
    iex:1: (file)
```

Since the clause was marked as internal and it never worked in `phoenix_html_helpers` and it was already deprecated I think it's safe to remove it.